### PR TITLE
fix/3435 bump lodash to 4.18.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5540,9 +5540,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {


### PR DESCRIPTION
## Summary

**Security issue:** Not triage-verified — this ticket carries a `Security` tag and the title flags a Critical lodash vulnerability, but no triage classification comment (`is_security_issue`/`security_classification`) was present on the work item, so the action agent fell back to parsing the description for the affected repo. Treat the security relevance as **unconfirmed** pending human review.

Aikido reported lodash as affected by 3 vulnerabilities (1 critical, 2 medium). This PR bumps the transitive `lodash` dependency from 4.17.21 to 4.18.1 in `package-lock.json`. lodash is a transitive dependency here, so `package.json` is unchanged; both dependents' ranges (`^4.15.0` and `^4.17.21`) are satisfied by 4.18.1.

## Changed files

- `package-lock.json` — bumped the resolved `node_modules/lodash` entry from 4.17.21 to 4.18.1 (version/resolved/integrity)

## Fix type

Security / Dependency Version Bump (triage custom fields were not populated on this ticket; inferred from the Aikido finding)

---

Automated fix for [AB#3435](https://dev.azure.com/chillipharm/Issues%20and%20Vulnerabilities/_workitems/edit/3435), generated by the ChilliPharm fix-flow action agent from a triaged work item. Review before merging like any other PR.